### PR TITLE
fix: update OpenAPI schema and add API root route

### DIFF
--- a/app/api/route.js
+++ b/app/api/route.js
@@ -1,0 +1,3 @@
+export async function GET() {
+  return Response.json({ message: 'API root' });
+}

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -5,7 +5,7 @@ info:
   version: "1.0.0"
 
 servers:
-  - url: "https://chatgpt-gis-vercel.vercel.app/api"
+  - url: "https://chatgpt-gis-vercel.vercel.app"
     description: Production API server
 
 tags:
@@ -19,7 +19,7 @@ tags:
     description: Utility and placeholder endpoints
 
 paths:
-  /ping:
+  /api/ping:
     get:
       tags:
         - Health
@@ -38,7 +38,7 @@ paths:
                     type: string
                     example: pong
 
-  /parcel-summary:
+  /api/parcel-summary:
     get:
       tags:
         - Statewide
@@ -90,7 +90,7 @@ paths:
                           type: string
                           example: "03200001000"
 
-  /metro:
+  /api/metro:
     get:
       tags:
         - Metro
@@ -133,7 +133,7 @@ paths:
                           type: string
                           example: "zoning='R10'"
 
-  /tn:
+  /api/tn:
     get:
       tags:
         - Statewide
@@ -176,7 +176,7 @@ paths:
                           type: string
                           example: "county='Davidson'"
 
-  /parcel:
+  /api/parcel:
     get:
       tags:
         - Utilities


### PR DESCRIPTION
## Summary
- point OpenAPI server to `https://chatgpt-gis-vercel.vercel.app`
- prefix all API routes with `/api`
- add API root route so server URL responds for validation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npx vercel deploy --prebuilt` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*

------
https://chatgpt.com/codex/tasks/task_e_68af82894c80832a95c620a1761f6852