### PR TITLE
fix: update OpenAPI schema and add API root route

### DIFF
--- a/app/api/route.js
+++ b/app/api/route.js
@@ -1,0 +1,3 @@
+export async function GET() {
+  return Response.json({ message: 'API root' });
+}


### PR DESCRIPTION
## Summary
- point OpenAPI server to `https://chatgpt-gis-vercel.vercel.app/api`
- prefix API base path using server URL instead of individual paths
- add API root route so server URL responds for validation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npx vercel deploy --prebuilt` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*

------
https://chatgpt.com/codex/tasks/task_e_68af82894c80832a95c620a1761f6852